### PR TITLE
Fix bug in authentication

### DIFF
--- a/lib/omniauth/strategies/survey_monkey.rb
+++ b/lib/omniauth/strategies/survey_monkey.rb
@@ -65,6 +65,10 @@ module OmniAuth
         end
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       private
 
       def prune!(hash)


### PR DESCRIPTION
It looks like there's an issue with how omniauth-oauth2 is constructing the redirect_uri for this that's causing survey monkey to reject authorization. We implemented the same workaround that the [twitch strategy did](https://github.com/WebTheoryLLC/omniauth-twitch/commit/3032f76de1c235e8a104fa25b650359ab62b4456) and it fixed the issue when we monkey patched this strategy in our project. Wanted to see if we could get the change upstream so that it would work for anyone else as well