### PR TITLE
Add auth scheme for survey monkey

### DIFF
--- a/lib/omniauth/strategies/survey_monkey.rb
+++ b/lib/omniauth/strategies/survey_monkey.rb
@@ -28,7 +28,8 @@ module OmniAuth
       option :client_options, {
         :site           => 'https://api.surveymonkey.net',
         :authorize_url  => '/oauth/authorize',
-        :token_url      => '/oauth/token'
+        :token_url      => '/oauth/token',
+        :auth_scheme => 'request_body'
       }
 
       option :name, 'surveymonkey'


### PR DESCRIPTION
Uprading `oauth2`to version 2.0.9 https://rubygems.org/gems/oauth2/versions/2.0.9 introduces breaking changes with `:auth_scheme`. The default value in 2.X.X is `:basic_auth` but it used to be `:request_body` in 1.X.X https://github.com/oauth-xx/oauth2/blob/main/lib/oauth2/client.rb#L54 and notes here https://github.com/oauth-xx/oauth2/tree/main?tab=readme-ov-file#what-is-new-for-v20 

Default value in 1.X.X https://gitlab.com/oauth-xx/oauth2/-/blob/1-4-stable/lib/oauth2/client.rb?ref_type=heads#L44

Some integrations still rely on `request_body` and survey monkey is one of them so adding this